### PR TITLE
fix: wrap code blocks, adjust some content to fit

### DIFF
--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -12,6 +12,10 @@
         color: $linkColour;
     }
 
+    code {
+        white-space: pre-wrap;
+    }
+
     h1,
     h2,
     h3,

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -13,7 +13,8 @@
     }
 
     code {
-        white-space: pre-wrap;
+        display: block;
+        overflow: auto;
     }
 
     h1,

--- a/src/collections/techniques/en-CA/WAI-ARIA.md
+++ b/src/collections/techniques/en-CA/WAI-ARIA.md
@@ -15,9 +15,12 @@ page. For example, a list of text items used as a toolbar or navigation menu can
 ```html
 <nav>
     <ul class="buttons" title="Website navigation">
-        <li id="Home" aria-labelledby="navigation_home" aria-controls="my_content" aria-pressed="false" tabindex="0" role="button">Home</li>
-        <li id="Blog" aria-labelledby="navigation_blog" aria-controls="my_content" aria-pressed="false" tabindex="0" role="button">Blog</li>
-        <li id="About" aria-labelledby="navigation_about" aria-controls="my_content" aria-pressed="false" tabindex="0" role="button">About</li>
+        <li id="Home" aria-labelledby="navigation_home" aria-controls="my_content"
+            aria-pressed="false" tabindex="0" role="button">Home</li>
+        <li id="Blog" aria-labelledby="navigation_blog" aria-controls="my_content"
+            aria-pressed="false" tabindex="0" role="button">Blog</li>
+        <li id="About" aria-labelledby="navigation_about" aria-controls="my_content"
+            aria-pressed="false" tabindex="0" role="button">About</li>
      </ul>
 </nav>
 


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This update solves `code` element wrapping issues and adjusts one page's content to fit slightly better.

## Steps to test

1. Go to http://localhost:8080/techniques/wai-aria/ after running the local server

**Expected behavior:** the code samples in the page content should wrap to fit their container

## Additional information

N/A

## Related issues

Resolves #56 
