### PR TITLE
fix: remove UIO text-size preference

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -67,6 +67,50 @@ module.exports = function (config) {
         return getResourceLinks(content, sideContentHeadings, lang);
     });
 
+    /*
+        Provide a custom duplicate of eleventy-plugin-fluid's uioInit shortcode in
+        order to run it without the text-size preference until issue #57 is solved
+
+        This is called from base.njk and home.njk
+
+        https://github.com/fluid-project/handbook.floeproject.org/issues/57
+    */
+    config.addShortcode("custom_uio", (locale, direction) => {
+        let options = {
+            preferences: [
+                "fluid.prefs.lineSpace",
+                "fluid.prefs.textFont",
+                "fluid.prefs.contrast",
+                "fluid.prefs.tableOfContents",
+                "fluid.prefs.enhanceInputs"
+            ],
+            auxiliarySchema: {
+                terms: {
+                    templatePrefix: "/lib/infusion/src/framework/preferences/html",
+                    messagePrefix: "/lib/infusion/src/framework/preferences/messages"
+                },
+                "fluid.prefs.tableOfContents": {
+                    enactor: {
+                        tocTemplate: "/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
+                        tocMessage: "/lib/infusion/src/framework/preferences/messages/tableOfContents-enactor.json",
+                        ignoreForToC: {
+                            ignoreClass: ".flc-toc-ignore"
+                        }
+                    }
+                }
+            },
+            prefsEditorLoader: {
+                lazyLoad: true
+            },
+            locale: locale,
+            direction: direction
+        };
+
+        var theThing = `<script>fluid.uiOptions.multilingual(".flc-prefsEditor-separatedPanel", ${JSON.stringify(options)});</script>`;
+
+        return theThing;
+    });
+
     // 404
     config.setBrowserSyncConfig({
         callbacks: {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -106,9 +106,7 @@ module.exports = function (config) {
             direction: direction
         };
 
-        var theThing = `<script>fluid.uiOptions.multilingual(".flc-prefsEditor-separatedPanel", ${JSON.stringify(options)});</script>`;
-
-        return theThing;
+        return `<script>fluid.uiOptions.multilingual(".flc-prefsEditor-separatedPanel", ${JSON.stringify(options)});</script>`;
     });
 
     // 404

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -75,7 +75,7 @@ module.exports = function (config) {
 
         https://github.com/fluid-project/handbook.floeproject.org/issues/57
     */
-    config.addShortcode("custom_uio", (locale, direction) => {
+    config.addShortcode("uioCustomInit", (locale, direction) => {
         let options = {
             preferences: [
                 "fluid.prefs.lineSpace",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@11ty/eleventy": "1.0.0",
                 "@11ty/eleventy-navigation": "0.3.2",
                 "@11ty/eleventy-plugin-syntaxhighlight": "3.2.2",
-                "eleventy-plugin-fluid": "0.3.1",
+                "eleventy-plugin-fluid": "1.0.0",
                 "infusion": "4.0.0",
                 "jsdom": "19.0.0"
             },
@@ -6093,52 +6093,14 @@
             }
         },
         "node_modules/eleventy-plugin-fluid": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-0.3.1.tgz",
-            "integrity": "sha512-RPbZxE/6IA2kZKQf6RmMG97nb2rytdYZfkE+hKqRqzuh4H/2LnJ8864rCXKTjKS7Jbt2aju/KPUFJViQBXzTWw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-1.0.0.tgz",
+            "integrity": "sha512-kDa7wPzlZn84FXiBWH6C70AM3MnmuPdAIg9pGZ6DpCT3rIvazHiXyoRkbFvWEsLhGSj/TcYOjRfSaTKUs0QwsQ==",
             "dependencies": {
-                "html-minifier": "4.0.0",
-                "markdown-it": "12.2.0",
-                "slugify": "1.6.0"
+                "html-minifier": "4.0.0"
             },
             "peerDependencies": {
                 "infusion": "4.x"
-            }
-        },
-        "node_modules/eleventy-plugin-fluid/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "node_modules/eleventy-plugin-fluid/node_modules/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/eleventy-plugin-fluid/node_modules/markdown-it": {
-            "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.2.0.tgz",
-            "integrity": "sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.js"
-            }
-        },
-        "node_modules/eleventy-plugin-fluid/node_modules/slugify": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
-            "integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang==",
-            "engines": {
-                "node": ">=8.0.0"
             }
         },
         "node_modules/elliptic": {
@@ -22805,42 +22767,11 @@
             }
         },
         "eleventy-plugin-fluid": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-0.3.1.tgz",
-            "integrity": "sha512-RPbZxE/6IA2kZKQf6RmMG97nb2rytdYZfkE+hKqRqzuh4H/2LnJ8864rCXKTjKS7Jbt2aju/KPUFJViQBXzTWw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-1.0.0.tgz",
+            "integrity": "sha512-kDa7wPzlZn84FXiBWH6C70AM3MnmuPdAIg9pGZ6DpCT3rIvazHiXyoRkbFvWEsLhGSj/TcYOjRfSaTKUs0QwsQ==",
             "requires": {
-                "html-minifier": "4.0.0",
-                "markdown-it": "12.2.0",
-                "slugify": "1.6.0"
-            },
-            "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-                },
-                "entities": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-                    "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-                },
-                "markdown-it": {
-                    "version": "12.2.0",
-                    "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.2.0.tgz",
-                    "integrity": "sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==",
-                    "requires": {
-                        "argparse": "^2.0.1",
-                        "entities": "~2.1.0",
-                        "linkify-it": "^3.0.1",
-                        "mdurl": "^1.0.1",
-                        "uc.micro": "^1.0.5"
-                    }
-                },
-                "slugify": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
-                    "integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang=="
-                }
+                "html-minifier": "4.0.0"
             }
         },
         "elliptic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@11ty/eleventy-navigation": "0.3.2",
                 "@11ty/eleventy-plugin-syntaxhighlight": "3.2.2",
                 "eleventy-plugin-fluid": "0.3.1",
-                "infusion": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
+                "infusion": "4.0.0",
                 "jsdom": "19.0.0"
             },
             "devDependencies": {
@@ -8960,9 +8960,9 @@
             }
         },
         "node_modules/infusion": {
-            "version": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
-            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703.tgz",
-            "integrity": "sha512-SKINSy296JpCLywlC4nVugeXzRp8Urle7hWV6NgOs9HsLOWOMfEy/jLj1UMr3aVWZCnxW+Syfr2ftVmWn4U6NA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0.tgz",
+            "integrity": "sha512-891gMT0UZTfGGahxNswqA62cnYpsgM5h+T8MGdyMlndT/pBpGj6m8+NCgnMjAgLwFyiEiRuyhXfQrFI2jeTz4Q==",
             "dependencies": {
                 "fluid-resolve": "1.3.0"
             },
@@ -24998,9 +24998,9 @@
             }
         },
         "infusion": {
-            "version": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
-            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703.tgz",
-            "integrity": "sha512-SKINSy296JpCLywlC4nVugeXzRp8Urle7hWV6NgOs9HsLOWOMfEy/jLj1UMr3aVWZCnxW+Syfr2ftVmWn4U6NA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0.tgz",
+            "integrity": "sha512-891gMT0UZTfGGahxNswqA62cnYpsgM5h+T8MGdyMlndT/pBpGj6m8+NCgnMjAgLwFyiEiRuyhXfQrFI2jeTz4Q==",
             "requires": {
                 "fluid-resolve": "1.3.0"
             }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@11ty/eleventy-navigation": "0.3.2",
         "@11ty/eleventy-plugin-syntaxhighlight": "3.2.2",
         "eleventy-plugin-fluid": "0.3.1",
-        "infusion": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
+        "infusion": "4.0.0",
         "jsdom": "19.0.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@11ty/eleventy": "1.0.0",
         "@11ty/eleventy-navigation": "0.3.2",
         "@11ty/eleventy-plugin-syntaxhighlight": "3.2.2",
-        "eleventy-plugin-fluid": "0.3.1",
+        "eleventy-plugin-fluid": "1.0.0",
         "infusion": "4.0.0",
         "jsdom": "19.0.0"
     },

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -13,7 +13,6 @@
         {% include "partials/global/icons.njk" %}
         <link rel="manifest" href="/manifest.webmanifest">
 
-        {% uioScripts %}
         {% include "partials/global/scripts.njk" %}
     </head>
     {# The pageBody block is used by the home page which has a different body layout #}
@@ -41,7 +40,15 @@
             </aside>
         </main>
         {% include "partials/global/footer.njk" %}
-        {% uioInit config.languages[lang].uioSlug, config.languages[lang].dir %}
+        {#
+            Calling a custom duplicate of eleventy-plugin-fluid's uioInit shortcode in
+            order to run it without the text-size preference until issue #57 is solved
+
+            This call is duplicated in home.njk
+
+            https://github.com/fluid-project/handbook.floeproject.org/issues/57
+        #}
+        {% custom_uio config.languages[lang].uioSlug, config.languages[lang].dir %}
     </body>
     {% endblock %}
 </html>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -48,7 +48,7 @@
 
             https://github.com/fluid-project/handbook.floeproject.org/issues/57
         #}
-        {% custom_uio config.languages[lang].uioSlug, config.languages[lang].dir %}
+        {% uioCustomInit config.languages[lang].uioSlug, config.languages[lang].dir %}
     </body>
     {% endblock %}
 </html>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -11,6 +11,14 @@
         {% endblock %}
     </main>
     {% include "partials/global/footer.njk" %}
-    {% uioInit config.languages[lang].uioSlug, config.languages[lang].dir %}
+    {# 
+        Calling a custom duplicate of eleventy-plugin-fluid's uioInit shortcode in
+        order to run it without the text-size preference until issue #57 is solved.
+        
+        This call is duplicated in base.njk
+
+        https://github.com/fluid-project/handbook.floeproject.org/issues/57
+    #}
+    {% custom_uio config.languages[lang].uioSlug, config.languages[lang].dir %}
 </body>
 {% endblock %}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -19,6 +19,6 @@
 
         https://github.com/fluid-project/handbook.floeproject.org/issues/57
     #}
-    {% custom_uio config.languages[lang].uioSlug, config.languages[lang].dir %}
+    {% uioCustomInit config.languages[lang].uioSlug, config.languages[lang].dir %}
 </body>
 {% endblock %}

--- a/src/utils/generatePermalink.js
+++ b/src/utils/generatePermalink.js
@@ -2,7 +2,7 @@
 
 const config = require("../_data/config.json");
 const getLang = require("./getLang.js");
-const slugFilter = require("../../node_modules/eleventy-plugin-fluid/src/filters/slug-filter.js");
+const TemplateConfig = require("@11ty/eleventy/src/TemplateConfig.js");
 const translations = require("../_data/translations.json");
 
 module.exports = (data, collectionType) => {
@@ -13,6 +13,8 @@ module.exports = (data, collectionType) => {
 
     const lang = getLang(data.page.filePathStem, collectionType);
     const langSlug = config.languages[lang].slug || lang;
+    const eleventyConfig = new TemplateConfig();
+    const slugFilter = eleventyConfig.userConfig.getFilter("slugify");
     const slug = slugFilter(data.title);
 
     if (collectionType === "pages") {


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This update will remove the UIO text-size preference in an attempt to address #57 in the short term. This was one of the solutions suggested when the issue was originally filed, as it's the approached used in the [WeCount website](https://wecount.inclusivedesign.ca/) which encountered similar issues.

Issue #57 should remain open after merging this PR, since the issue will not have been dealt with in what I consider a proper manner. This solution is not intended to be in place in the long term.

## Steps to test

1. Click on "+ show preferences"

**Expected behavior:** The "text size" preference should not be in the list of panels

## Additional information

N/A

## Related issues

Is a partial solution to #57 but does not solve the problem and therefore **_does not_** resolve the issue.