### PR TITLE
feat: transpile logical props for older browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
                 "move-file": "2.1.0",
                 "npm-run-all": "4.1.5",
                 "postcss": "8.4.5",
+                "postcss-dir-pseudo-class": "6.0.4",
+                "postcss-logical": "5.0.4",
                 "resolve-url-loader": "5.0.0",
                 "rimraf": "3.0.2",
                 "sass": "1.49.0",
@@ -8939,12 +8941,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/indexes-of": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-            "dev": true
-        },
         "node_modules/indexof": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -12674,6 +12670,21 @@
                 "postcss": "^8.2.15"
             }
         },
+        "node_modules/postcss-dir-pseudo-class": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz",
+            "integrity": "sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==",
+            "dev": true,
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.9"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >=16"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
         "node_modules/postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
@@ -12827,6 +12838,18 @@
                 "webpack": "^5.0.0"
             }
         },
+        "node_modules/postcss-logical": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
+            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+            "dev": true,
+            "engines": {
+                "node": "^12 || ^14 || >=16"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
         "node_modules/postcss-media-query-parser": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -12867,19 +12890,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
-            }
-        },
-        "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-            "dev": true,
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/postcss-minify-font-values": {
@@ -12947,19 +12957,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
-            }
-        },
-        "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-            "dev": true,
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/postcss-modules-extract-imports": {
@@ -13317,14 +13314,12 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+            "version": "6.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+            "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1",
                 "util-deprecate": "^1.0.2"
             },
             "engines": {
@@ -13407,19 +13402,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
-            }
-        },
-        "node_modules/postcss-unique-selectors/node_modules/postcss-selector-parser": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-            "dev": true,
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/postcss-value-parser": {
@@ -15994,19 +15976,6 @@
                 "url": "https://opencollective.com/postcss/"
             }
         },
-        "node_modules/stylelint/node_modules/postcss-selector-parser": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-            "dev": true,
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/stylelint/node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16710,12 +16679,6 @@
                 "vfile": "^2.0.0",
                 "x-is-string": "^0.1.0"
             }
-        },
-        "node_modules/uniq": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-            "dev": true
         },
         "node_modules/uniqs": {
             "version": "2.0.0",
@@ -24977,12 +24940,6 @@
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
-        "indexes-of": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-            "dev": true
-        },
         "indexof": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -27785,6 +27742,15 @@
                 "postcss-value-parser": "^4.1.0"
             }
         },
+        "postcss-dir-pseudo-class": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz",
+            "integrity": "sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.9"
+            }
+        },
         "postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
@@ -27879,6 +27845,13 @@
                 "semver": "^7.3.5"
             }
         },
+        "postcss-logical": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
+            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+            "dev": true,
+            "requires": {}
+        },
         "postcss-media-query-parser": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -27907,18 +27880,6 @@
                 "cssnano-utils": "^2.0.1",
                 "postcss-selector-parser": "^6.0.5",
                 "vendors": "^1.0.3"
-            },
-            "dependencies": {
-                "postcss-selector-parser": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-                    "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-                    "dev": true,
-                    "requires": {
-                        "cssesc": "^3.0.0",
-                        "util-deprecate": "^1.0.2"
-                    }
-                }
             }
         },
         "postcss-minify-font-values": {
@@ -27962,18 +27923,6 @@
             "requires": {
                 "alphanum-sort": "^1.0.2",
                 "postcss-selector-parser": "^6.0.5"
-            },
-            "dependencies": {
-                "postcss-selector-parser": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-                    "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-                    "dev": true,
-                    "requires": {
-                        "cssesc": "^3.0.0",
-                        "util-deprecate": "^1.0.2"
-                    }
-                }
             }
         },
         "postcss-modules-extract-imports": {
@@ -28216,14 +28165,12 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+            "version": "6.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+            "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1",
                 "util-deprecate": "^1.0.2"
             }
         },
@@ -28281,18 +28228,6 @@
                 "alphanum-sort": "^1.0.2",
                 "postcss-selector-parser": "^6.0.5",
                 "uniqs": "^2.0.0"
-            },
-            "dependencies": {
-                "postcss-selector-parser": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-                    "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-                    "dev": true,
-                    "requires": {
-                        "cssesc": "^3.0.0",
-                        "util-deprecate": "^1.0.2"
-                    }
-                }
             }
         },
         "postcss-value-parser": {
@@ -30295,16 +30230,6 @@
                         "source-map": "^0.6.1"
                     }
                 },
-                "postcss-selector-parser": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-                    "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-                    "dev": true,
-                    "requires": {
-                        "cssesc": "^3.0.0",
-                        "util-deprecate": "^1.0.2"
-                    }
-                },
                 "slash": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -30894,12 +30819,6 @@
                 "vfile": "^2.0.0",
                 "x-is-string": "^0.1.0"
             }
-        },
-        "uniq": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-            "dev": true
         },
         "uniqs": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
         "move-file": "2.1.0",
         "npm-run-all": "4.1.5",
         "postcss": "8.4.5",
+        "postcss-dir-pseudo-class": "6.0.4",
+        "postcss-logical": "5.0.4",
         "resolve-url-loader": "5.0.0",
         "rimraf": "3.0.2",
         "sass": "1.49.0",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -27,7 +27,11 @@ mix.sass("./src/assets/styles/main.scss", "dist/assets/styles");
 
 // Don't modify stylesheet url() functions.
 mix.options({
-    processCssUrls: false
+    processCssUrls: false,
+    postCss: [
+        require("postcss-dir-pseudo-class"),
+        require("postcss-logical")
+    ]
 });
 
 // Enable source maps.


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This update will transpile/polyfill CSS logical properties to be backwards compatible with older browsers by installing [the `postcss-logical` plugin](https://www.npmjs.com/package/postcss-logical).

## Steps to test

1. Inspect the "About" link element in the page navigation
2. Take note of the padding CSS rules on the `a` element

**Expected behavior:** The CSS class should be `[dir="ltr"] .menu__link` and the property used for the padding should be `padding-left` (rather than `padding-inline-start`).

## Additional information

N/A

## Related issues

Resolves #63
