### PR TITLE
feat: add collapse/expand buttons to root pages

### DIFF
--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -3,6 +3,8 @@
         "approaches": "approaches",
         "perspectives": "perspectives",
         "techniques": "techniques",
-        "menu": "Menu"
+        "menu": "Menu",
+        "collapseAll": "collapse all",
+        "expandAll": "expand all"
     }
 }

--- a/src/_includes/layouts/sections.njk
+++ b/src/_includes/layouts/sections.njk
@@ -5,6 +5,11 @@
         {{ content | safe }}
     </div>
 
+    <div class="sections-control">
+        <button class="sections-control__expand-all">{{ translations[lang].expandAll }}</button>
+        <button class="sections-control__collapse-all">{{ translations[lang].collapseAll }}</button>
+    </div>
+
     {% set sections = collections.all | eleventyNavigation(eleventyNavigation.key) %}
 
     <ul class="sections">

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -24,11 +24,11 @@ $(document).ready(function () {
             .toggleClass("section__content--show", state);
     };
     /** When "show all" button is clicked, expands all categories to show their contents. */
-    $(".sections__showAll").click(function () {
+    $(".sections-control__expand-all").click(function () {
         toggleCategory(".section__toggle", true);
     });
     /** When "hide all" button is clicked, collapses all categories to hide their contents. */
-    $(".sections__hideAll").click(function () {
+    $(".sections-control__collapse-all").click(function () {
         toggleCategory(".section__toggle", false);
     });
     $(".section__toggle").click(function (evt) {

--- a/src/assets/styles/pages/_sections.scss
+++ b/src/assets/styles/pages/_sections.scss
@@ -3,3 +3,24 @@
     margin: 0;
     padding: 0;
 }
+
+.sections-control {
+    margin-block-end: 1.5rem;
+    margin-block-start: 2rem;
+}
+
+.sections-control__expand-all {
+    margin-inline-end: 1.25rem;
+}
+
+.sections-control__collapse-all,
+.sections-control__expand-all {
+    background: var(--fl-buttonBgColor, $rootContentBackgroundColour);
+    border: 1px solid $mainColour;
+    color: var(--fl-buttonFgColor, $mainColour);
+    cursor: pointer;
+    font-size: 1.125rem;
+    font-weight: var(--fl-enhance-font-weight, 600);
+    line-height: calc(var(--fl-lineSpace-factor, 1) * 1.875);
+    padding: 0.375rem 1.5rem;
+}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This update adds "collapse all" and "expand all" buttons to the root pages, Approaches and Techniques

## Steps to test

1. Go to the Approaches page
2. Click on the "expand all" button
3. Click on the "collapse all" button

**Expected behavior:** Clicking "expand all" should open all four accordions, clicking "collapse all" should close them.

## Additional information

The buttons are idempotent and should not cause any further action after clicking more than once in a row.

## Related issues

Resolves #58 
