### PR TITLE
fix: add missing UIO Enhance CSS custom properties

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ lang }}" dir="{{ config.languages[lang].dir }}">
+<html lang="{% if lang %}{{ lang }}{% else %}en-CA{% endif %}" dir="{% if lang %}{{ config.languages[lang].dir }}{% else %}ltr{% endif %}">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width">

--- a/src/assets/styles/abstracts/_variables.scss
+++ b/src/assets/styles/abstracts/_variables.scss
@@ -19,7 +19,7 @@ $footerColour: var(--fl-fgColor, #fff);
 $footerBGColour: var(--fl-bgColor, #153647);
 $footerLinkColour: var(--fl-linkColor, var(--fl-fgColor, #cfca6f));
 $rootContentColour: var(--fl-bgColor, #000);
-$rootContentBackgroundColour: var(--fl-bgColor, #e7f0f3);
+$rootContentBackgroundColour: var(--fl-bgColor, #f3f7f9);
 $topicContentBackgroundColour: var(--fl-bgColor, #f9faf6);
 $menuTitleColour: $darkRed;
 $menuExpandedColour: var(--fl-fgColor, #000);

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -13,6 +13,10 @@
     }
 
     code {
+        display: inline;
+    }
+
+    pre code {
         display: block;
         overflow: auto;
     }
@@ -53,6 +57,7 @@
         margin-inline: 0;
     }
 
+    ol,
     p,
     ul {
         font-size: 1.25rem;

--- a/src/assets/styles/components/_menu.scss
+++ b/src/assets/styles/components/_menu.scss
@@ -64,7 +64,7 @@
     background-color: var(--fl-bgColor, $menuExpandedBGColour);
     color: var(--fl-linkColor, $menuExpandedColour);
     display: flex;
-    font-size: 1.5rem;
+    font-size: var(--fl-enhance-font-size, 1.5rem);
     font-weight: var(--fl-enhance-font-weight, 500);
     height: 3.5rem;
     line-height: 1.875rem;

--- a/src/assets/styles/components/_section-accordion.scss
+++ b/src/assets/styles/components/_section-accordion.scss
@@ -10,7 +10,8 @@
     color: var(--fl-buttonFgColor, $mainColour);
     cursor: pointer;
     display: flex;
-    font-size: 1.375rem;
+    font-size: var(--fl-enhance-font-size, 1.8125rem);
+    font-weight: var(--fl-enhance-font-weight, 700);
     justify-content: space-between;
     line-height: calc(var(--fl-lineSpace-factor, 1) * 1.45);
     margin-block-end: 1.25rem;
@@ -26,7 +27,6 @@
 .section__title {
     border: 0.0625rem dashed var(--fl-buttonBgColor, $sectionBorderColour);
     border-inline-start: none;
-    font-size: 1.8125rem;
     line-height: 1.875rem;
     padding: 1rem 1rem 1rem 1.25rem;
     text-align: start;
@@ -36,7 +36,6 @@
 .section__toggle--expanded .section__title {
     border: 0.35rem solid var(--fl-buttonFgColor, $sectionBorderColour);
     border-inline-start: none;
-    font-weight: var(--fl-enhance-font-weight, 700);
     padding: 0.7125rem 1rem 0.7125rem 1.25rem;
 }
 
@@ -82,13 +81,12 @@
 }
 
 .section__subsection {
-    font-size: var(--fl-enhance-font-size, 1.125rem);
     margin-block-end: 1rem;
 }
 
 .section__subsection-link {
-    font-size: 1.5rem;
-    font-weight: 500;
+    font-size: var(--fl-enhance-font-size, 1.5rem);
+    font-weight: var(--fl-enhance-font-weight, 500);
     line-height: 3rem;
     padding-block-end: 0.15rem;
 }


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Correct existing and add missing UIO Enhance preference CSS custom properties

## Steps to test

1. Click on "+ show preferences"
2. Set the "enhance inputs" to "ON"

**Expected behavior:** All links and buttons should have greater font weight and size, all links should receive underline

## Additional information

This update also addresses a few CSS bugs I found along the way

## Related issues

Resolves #64 
