### PR TITLE
chore: update changelog with v1.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
 ## 1.0.0 (2022-03-10)
 
 ### ⚠ BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+## 1.0.0 (2022-03-10)
+
+### ⚠ BREAKING CHANGES
+
+* This release implements the ILDH site redesign described in this [Figma file](https://www.figma.com/file/JVjWAROz9jZBbDaemwom2y/ILDH?node-id=0%3A1).
+  The previous Eleventy conversion (which has no official release) has been replaced with a structure based on [Trivet](https://github.com/fluid-project/trivet),
+  including switching Stylus out for Sass as the CSS preprocessor. Additionally, the Sass 7-1 directory structure and
+  BEM have been used to organize styling rules. Some content (editorial) and tooling updates have also been incorporated
+  into this release.
+
+  This update represents a work in progress, and further issues were filed to complete the work of implementing the design
+  to its exact specifications. This further work is to form the basis of the future `v1.1.0`.


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR updates the changelog to include details about the `v1.0.0` release from March 10th, 2022.

## Steps to test

N/A

## Additional information

Once this PR is merged, the `v1.0.0` release will be cut based on the previously created tag.

## Related issues

N/A
