### PR TITLE
fix: remove Literata from homepage styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@11ty/eleventy-navigation": "0.3.2",
                 "@11ty/eleventy-plugin-syntaxhighlight": "3.2.2",
                 "eleventy-plugin-fluid": "0.3.1",
-                "infusion": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
+                "infusion": "4.0.0",
                 "jsdom": "19.0.0"
             },
             "devDependencies": {
@@ -3263,9 +3263,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3280,6 +3280,17 @@
             "dependencies": {
                 "acorn": "^7.1.1",
                 "acorn-walk": "^7.1.1"
+            }
+        },
+        "node_modules/acorn-globals/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/acorn-globals/node_modules/acorn-walk": {
@@ -6768,6 +6779,18 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/espree/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -8960,9 +8983,9 @@
             }
         },
         "node_modules/infusion": {
-            "version": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
-            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703.tgz",
-            "integrity": "sha512-SKINSy296JpCLywlC4nVugeXzRp8Urle7hWV6NgOs9HsLOWOMfEy/jLj1UMr3aVWZCnxW+Syfr2ftVmWn4U6NA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0.tgz",
+            "integrity": "sha512-891gMT0UZTfGGahxNswqA62cnYpsgM5h+T8MGdyMlndT/pBpGj6m8+NCgnMjAgLwFyiEiRuyhXfQrFI2jeTz4Q==",
             "dependencies": {
                 "fluid-resolve": "1.3.0"
             },
@@ -9143,6 +9166,17 @@
             "dependencies": {
                 "acorn": "^7.1.1",
                 "object-assign": "^4.1.1"
+            }
+        },
+        "node_modules/is-expression/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/is-extendable": {
@@ -9577,17 +9611,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/jsdom/node_modules/ws": {
@@ -16518,18 +16541,6 @@
                 }
             }
         },
-        "node_modules/ts-node/node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -17495,18 +17506,6 @@
             "dependencies": {
                 "source-list-map": "^2.0.0",
                 "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/webpack/node_modules/acorn": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/webpack/node_modules/schema-utils": {
@@ -20542,9 +20541,9 @@
             }
         },
         "acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
         },
         "acorn-globals": {
             "version": "6.0.0",
@@ -20555,6 +20554,11 @@
                 "acorn-walk": "^7.1.1"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
                 "acorn-walk": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -23338,6 +23342,12 @@
                 "eslint-visitor-keys": "^1.3.0"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                },
                 "eslint-visitor-keys": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -24998,9 +25008,9 @@
             }
         },
         "infusion": {
-            "version": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
-            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703.tgz",
-            "integrity": "sha512-SKINSy296JpCLywlC4nVugeXzRp8Urle7hWV6NgOs9HsLOWOMfEy/jLj1UMr3aVWZCnxW+Syfr2ftVmWn4U6NA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/infusion/-/infusion-4.0.0.tgz",
+            "integrity": "sha512-891gMT0UZTfGGahxNswqA62cnYpsgM5h+T8MGdyMlndT/pBpGj6m8+NCgnMjAgLwFyiEiRuyhXfQrFI2jeTz4Q==",
             "requires": {
                 "fluid-resolve": "1.3.0"
             }
@@ -25124,6 +25134,13 @@
             "requires": {
                 "acorn": "^7.1.1",
                 "object-assign": "^4.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                }
             }
         },
         "is-extendable": {
@@ -25432,11 +25449,6 @@
                 "xml-name-validator": "^4.0.0"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "8.7.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
-                },
                 "ws": {
                     "version": "8.5.0",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
@@ -30755,14 +30767,6 @@
                 "diff": "^4.0.1",
                 "make-error": "^1.1.1",
                 "yn": "3.1.1"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "8.7.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-                    "dev": true
-                }
             }
         },
         "tslib": {
@@ -31187,12 +31191,6 @@
                 "webpack-sources": "^3.2.0"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-                    "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-                    "dev": true
-                },
                 "schema-utils": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@11ty/eleventy-navigation": "0.3.2",
         "@11ty/eleventy-plugin-syntaxhighlight": "3.2.2",
         "eleventy-plugin-fluid": "0.3.1",
-        "infusion": "4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703",
+        "infusion": "4.0.0",
         "jsdom": "19.0.0"
     },
     "devDependencies": {

--- a/src/assets/styles/pages/_home.scss
+++ b/src/assets/styles/pages/_home.scss
@@ -59,8 +59,6 @@
 
     h2 {
         color: $darkRed;
-        font-family: $family-serif;
-        font-style: italic;
         margin-block: 1rem;
         text-align: center;
     }

--- a/src/assets/styles/pages/_home.scss
+++ b/src/assets/styles/pages/_home.scss
@@ -16,7 +16,6 @@
 .home__intro {
     background: $homeIntroBGColour;
     color: $homeIntroColour;
-    font-family: $family-serif;
     font-size: 2.375rem;
     line-height: 3.4375rem;
     padding-block: 1rem;


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This update removes the [Literata](https://fonts.google.com/specimen/Literata) typeface from the home page content in order to improve readability and load times. It is still used for the Menu popup title on narrow/mobile layouts, however this is subject to lazy loading, hence the performance improvements.

## Steps to test

1. Go to the homepage

**Expected behavior:** The intro copy ("The FLOE _Inclusive Learning_...") and the "_Get Involved_" heading should be rendered in Work Sans rather than Literata

![image](https://user-images.githubusercontent.com/547933/171478185-6beed206-5d3c-4296-83ca-083580c60c8c.png)

![image](https://user-images.githubusercontent.com/547933/171478217-c043c22b-a62f-4b2f-a8ad-f144d90bffe4.png)

## Additional information

Given that the only remaining uses of Literata on the site (the "Menu" title and root page `h1`'s) are a single weight (800) and not subject to UIO weight increases (from the "Enhance inputs" preference), and given that @carenwatkins noted rendering issues with the variable font vs. the design, I attempted to switch to a static font file for 800-weight only. Unfortunately, this ended up looking even worse, further from the spec and with poor kerning, so I abandoned this effort for the time being.

Futhermore, npm raised a peer dependency issue relating to the version of `infusion` listed in `package.json`, so I updated that from `4.0.0-dev.20211216T180403Z.d5f6173fc.FLUID-6703` to the full release of `4.0.0`.

## Related issues

N/A, no issue filed