### PR TITLE
fix: mobile menu label

### DIFF
--- a/src/_includes/partials/components/menu.njk
+++ b/src/_includes/partials/components/menu.njk
@@ -1,11 +1,11 @@
 <nav class="menu" aria-label="menu">
     <button class="menu__button" aria-label="menu" aria-expanded="false" aria-controls="menu-list" type="button">
         {% svg_sprite "icon-menu" %}
-        <span class="menu__name">{_("Menu")}</span>
+        <span class="menu__name">{{ _("Menu") }}</span>
     </button>
 
     <div class="menu__panel">
-        <h2 class="menu__title">{_("Menu")}</h2>
+        <h2 class="menu__title">{{ _("Menu") }}</h2>
 
         <ul id="menu-list" class="menu__list">
             {% set siteNav = collections.all | eleventyNavigation("Home") %}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves issue reported by @carenwatkins.

## Steps to test

1. Visit site on mobile.

**Expected behavior:** Menu should be labelled properly, compare with https://handbook.floeproject.org
