### PR TITLE
fix: remove hyphens rules

### DIFF
--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -43,7 +43,6 @@ a:hover {
     h3,
     p,
     ul {
-        hyphens: auto;
         word-break: break-word;
     }
 

--- a/src/assets/styles/components/_audio-tactile-card.scss
+++ b/src/assets/styles/components/_audio-tactile-card.scss
@@ -6,7 +6,6 @@
         border-block-start: none;
         box-sizing: border-box;
         font-size: 1.25rem;
-        hyphens: auto;
         line-height: 2rem;
         padding: 0.1875rem; /* This padding reserves space for the thicker border on hover & focus */
         padding-block-start: 0;
@@ -96,7 +95,6 @@
 
     @include mixins.breakpoint-up(sm) {
         .card__details {
-            hyphens: unset;
             word-break: unset;
         }
     }

--- a/src/assets/styles/pages/_audio-tactile.scss
+++ b/src/assets/styles/pages/_audio-tactile.scss
@@ -18,7 +18,6 @@
         font-size: 3rem;
         font-weight: 700;
         grid-area: title;
-        hyphens: auto;
         line-height: 3.5rem;
         word-break: break-word;
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [ ] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

When word break is happening to the next line, words got hyphenated because of the css hyphens rule is set to auto. Remove the css style to fix this issue.
