### PR TITLE
fix: typeo in the navigation menu

### DIFF
--- a/src/collections/approaches/en-CA/SVGAndAccessibility.md
+++ b/src/collections/approaches/en-CA/SVGAndAccessibility.md
@@ -3,7 +3,7 @@ title: SVG and Accessibility
 subheader:
 eleventyNavigation:
     parent: Inclusive Authoring
-    key: SVG and Accessiblity
+    key: SVG and Accessibility
     order: 7
 ---
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Fix typeo in nav menu in /approaches/svg-and-accessibility.
